### PR TITLE
fix pick() documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,9 +478,9 @@ from ebbe import pick
 pick({'a': 1, 'b': 2, 'c': 3}, ['a', 'c'])
 >>> {'a': 1, 'c': 3}
 
-# If you need the function to raise of one of the picked keys is not found:
-pick({'a': 1, 'b': 2, 'c': 3}, ['a', 'd'])
->>> TypeError
+# If you need the function to raise if one of the picked keys is not found:
+pick({'a': 1, 'b': 2, 'c': 3}, ['a', 'd'], strict=True)
+>>> KeyError: 'd'
 ```
 
 ### omit


### PR DESCRIPTION
The new pick() method was wrongly documented in README. This PR:

- [x] replaced "of" with "if"
- [x] added `strict=True` kwarg in second example
- [x] replaced TypeError with KeyError