### PR TITLE
Fix TypeError catch for getPath exception

### DIFF
--- a/ebbe/utils.py
+++ b/ebbe/utils.py
@@ -153,7 +153,7 @@ def getpath(
         if items and callable(getattr(target, "__getitem__", None)):
             try:
                 target = target[step]
-            except (IndexError, KeyError):
+            except (IndexError, KeyError, TypeError):
                 return default
         elif attributes:
             try:


### PR DESCRIPTION
When the path of `getPath()` is wrong and explored path is a `list` instead of an excepted `dict`, the function raises an exception instead of returning `None`. This PR fixes that by adding `TypeError` as condition for returning `default`.